### PR TITLE
remove incorrect rewrite

### DIFF
--- a/weights.py
+++ b/weights.py
@@ -118,9 +118,6 @@ class WeightsDownloadCache:
 
         st = time.time()
         # maybe retry with the real url if this doesn't work
-        url = url.replace(
-            "replicate.delivery/pbxt", "replicate-files.object.lga1.coreweave.com"
-        )
         try:
             print(f"downloading {url}")
             output = subprocess.check_output(["pget", "-x", url, dest], close_fds=True)


### PR DESCRIPTION
this rewriting of where to download weights is no longer valid.  And started breaking a couple days ago.